### PR TITLE
remove mistakenly  double typed word

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -38,7 +38,7 @@ You can install `Apollo.framework` into your project using any of the three majo
 
 You'll have to copy or [download a schema](/downloading-schema/) to your target's directory before generating code.
 
-Apollo iOS requires a GraphQL schema file as input to the code generation process. A schema file is a JSON file that contains the results of an an introspection query. Conventionally this file is called `schema.json`.
+Apollo iOS requires a GraphQL schema file as input to the code generation process. A schema file is a JSON file that contains the results of an introspection query. Conventionally this file is called `schema.json`.
 
 Note that you need to add this in the folder where most of your code is, NOT in the same folder where the `.xcodeproj` and/or `.xcworkspace` are located. Here is a rough ASCII representation of what this should look like: 
 


### PR DESCRIPTION
I came across a typo of the same word twice by mistake.Then I removed it so it would be easy to read